### PR TITLE
Improved transcode config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -380,9 +380,9 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babbling": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/babbling/-/babbling-1.18.1.tgz",
-      "integrity": "sha512-+c6MGWoCTdxfUFLsAcujyvjHVFcrlvE0NCtljkA1eDFdp61aGQYZVoaSdIlB9HC03X3iwIfhx/DItJCCOAVTGw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/babbling/-/babbling-1.19.0.tgz",
+      "integrity": "sha512-iubV7JwwDk+mGNrsNqkKxaEzS8GOymWNhvZ1k+/Kkq4VVULm70ZAGC+Yxo/0bsSrhRn3ex+Uv9ECwNi1IpfLLQ==",
       "requires": {
         "chakram-ts": "^1.0.0",
         "chromagnon": "^1.0.2",
@@ -390,6 +390,7 @@
         "fs-extra": "^7.0.1",
         "jsonwebtoken": "^8.5.1",
         "leven": "^3.1.0",
+        "mdns": "^2.5.1",
         "nodecastor": "github:dhleong/nodecastor#e18189c",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dhleong/shougun#readme",
   "dependencies": {
-    "babbling": "^1.18.1",
+    "babbling": "^1.19.0",
     "better-sqlite3": "^5.4.3",
     "chokidar": "^3.2.2",
     "crc": "^3.8.0",

--- a/src/media/analyze.ts
+++ b/src/media/analyze.ts
@@ -1,0 +1,87 @@
+import {
+    ffprobe as ffprobeCallback,
+    FfprobeData,
+    FfprobeStream,
+} from "fluent-ffmpeg";
+
+const ffprobe = (localPath: string) => new Promise<FfprobeData>((resolve, reject) => {
+    ffprobeCallback(localPath, (err, data) => {
+        if (err) reject(err);
+        else resolve(data);
+    });
+});
+
+export interface IAudioTrack {
+    codec: string;
+    profile?: string;
+}
+
+export interface IVideoTrack {
+    codec: string;
+    fps?: number;
+    level?: number;
+    profile?: string;
+
+    width: number;
+    height: number;
+}
+
+export interface IVideoAnalysis {
+    audio: IAudioTrack;
+    video: IVideoTrack;
+
+    container: string[];
+    duration: number;
+}
+
+export async function analyzeFile(
+    localPath: string,
+) {
+    const data = await ffprobe(localPath);
+
+    let videoTrack: IVideoTrack | undefined;
+    let audioTrack: IAudioTrack | undefined;
+    for (const s of data.streams) {
+        if (!videoTrack && s.codec_type === "video") {
+            videoTrack = parseVideoTrack(s);
+        }
+
+        if (!audioTrack && s.codec_type === "audio") {
+            audioTrack = parseAudioTrack(s);
+        }
+
+        if (videoTrack && audioTrack) {
+            break;
+        }
+    }
+
+    return {
+        audio: audioTrack!,
+        video: videoTrack!,
+
+        container: data.format.format_name!.split(","),
+        duration: data.format.duration,
+    } as IVideoAnalysis;
+}
+
+function parseAudioTrack(s: FfprobeStream): IAudioTrack {
+    return {
+        codec: s.codec_name!,
+        profile: s.profile as unknown as string,
+    };
+}
+
+function parseVideoTrack(s: FfprobeStream): IVideoTrack {
+    const [ fpsNum, fpsDen ] = (s.avg_frame_rate || "0/1").split("/");
+    return {
+        codec: s.codec_name!,
+        fps: parseInt(fpsNum, 10) / parseInt(fpsDen, 10),
+
+        // I think these types got flipped:
+        level: s.level as unknown as number,
+        profile: s.profile as unknown as string,
+
+        height: s.height!,
+        width: s.width!,
+    };
+}

--- a/src/media/analyze.ts
+++ b/src/media/analyze.ts
@@ -20,6 +20,7 @@ export interface IVideoTrack {
     codec: string;
     fps?: number;
     level?: number;
+    pixelFormat?: string;
     profile?: string;
 
     width: number;
@@ -76,6 +77,7 @@ function parseVideoTrack(s: FfprobeStream): IVideoTrack {
     return {
         codec: s.codec_name!,
         fps: parseInt(fpsNum, 10) / parseInt(fpsDen, 10),
+        pixelFormat: s.pix_fmt,
 
         // I think these types got flipped:
         level: s.level as unknown as number,

--- a/src/media/duration.ts
+++ b/src/media/duration.ts
@@ -1,25 +1,16 @@
 import _debug from "debug";
 const debug = _debug("shougun:duration");
 
-import ffmpeg from "fluent-ffmpeg";
-
-const ffprobe = (
-    filePath: string,
-) => new Promise<ffmpeg.FfprobeData>((resolve, reject) => {
-    ffmpeg.ffprobe(filePath, (err, data) => {
-        if (err) reject(err);
-        else resolve(data);
-    });
-});
+import { analyzeFile } from "./analyze";
 
 export async function extractDuration(
     localPath: string,
 ): Promise<number> {
-    const data = await ffprobe(localPath);
-    if (!data.format.duration) {
-        debug("full format=", data.format);
+    const data = await analyzeFile(localPath);
+    if (!data.duration) {
+        debug("full analysis=", data);
         throw new Error(`Unable to extract duration of ${localPath}`);
     }
 
-    return data.format.duration;
+    return data.duration;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,6 @@
 import { Context } from "./context";
 import { DiscoveryId } from "./discover/base";
+import { IVideoAnalysis } from "./media/analyze";
 import { IPlaybackOptions } from "./playback/player";
 
 export interface ILocalMedia {
@@ -31,6 +32,12 @@ export interface IPlayable {
     readonly media: IMedia;
 
     loadQueueAround(context: Context): Promise<IMedia[]>;
+
+    /**
+     * If available (IE: a local media file), fetch an analysis
+     * of the media
+     */
+    analyze?(): Promise<IVideoAnalysis>;
 
     /**
      * Get an URL that can be used to stream the media represented

--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -1,6 +1,6 @@
 
 import { Context } from "../context";
-import { IAudioTrack, IVideoTrack } from "../media/analyze";
+import { IAudioTrack, IVideoAnalysis, IVideoTrack } from "../media/analyze";
 import { IMedia, IPlayable } from "../model";
 
 export interface IPlaybackOptions {
@@ -39,4 +39,16 @@ export interface IPlayer {
         context: Context,
         recommendations: Promise<IMedia[]>,
     ): Promise<void>;
+}
+
+export function canPlayNatively(
+    capabilities: IPlayerCapabilities,
+    analysis: IVideoAnalysis | null,
+) {
+    if (!analysis) return false; // assume no, I guess
+
+    const videoSupported = capabilities.supportsVideoTrack(analysis.video);
+    const audioSupported = capabilities.supportsAudioTrack(analysis.audio);
+    const containerSupported = !!analysis.container.find(capabilities.supportsContainer.bind(capabilities));
+    return videoSupported && audioSupported && containerSupported;
 }

--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -20,7 +20,6 @@ export interface IPlaybackOptions {
 }
 
 export interface IPlayerCapabilities {
-    canPlayMime(mime: string): boolean;
     supportsAudioTrack(track: IAudioTrack): boolean;
     supportsVideoTrack(track: IVideoTrack): boolean;
     supportsContainer(container: string): boolean;

--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -1,5 +1,6 @@
 
 import { Context } from "../context";
+import { IAudioTrack, IVideoTrack } from "../media/analyze";
 import { IMedia, IPlayable } from "../model";
 
 export interface IPlaybackOptions {
@@ -20,10 +21,13 @@ export interface IPlaybackOptions {
 
 export interface IPlayerCapabilities {
     canPlayMime(mime: string): boolean;
+    supportsAudioTrack(track: IAudioTrack): boolean;
+    supportsVideoTrack(track: IVideoTrack): boolean;
+    supportsContainer(container: string): boolean;
 }
 
 export interface IPlayer {
-    getCapabilities(): IPlayerCapabilities;
+    getCapabilities(): Promise<IPlayerCapabilities>;
 
     play(
         context: Context,

--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -24,6 +24,7 @@ export interface IPlayerCapabilities {
     supportsAudioTrack(track: IAudioTrack): boolean;
     supportsVideoTrack(track: IVideoTrack): boolean;
     supportsContainer(container: string): boolean;
+    supportsPixelFormat?(format: string): boolean;
 }
 
 export interface IPlayer {

--- a/src/playback/player/chromecast.ts
+++ b/src/playback/player/chromecast.ts
@@ -84,7 +84,7 @@ const ultraCapabilities = {
             if ((track.fps || 24) > 60) return false;
             if (
                 track.profile !== "Main"
-                && track.profile !== "Main10"
+                && track.profile !== "Main 10"
             ) return false;
 
             return true;

--- a/src/playback/player/chromecast.ts
+++ b/src/playback/player/chromecast.ts
@@ -48,10 +48,11 @@ const ultraCapabilities = {
         "vorbis",
     ]),
 
+    // NOTE: chromecast supports matroska and webm containers, but doesn't
+    // seem to properly support seeking within them, so we just do a
+    // passthrough transcode and use shougun-cast-player to handle seeking
     containers: new Set([
         "mp4",
-        "matroska",
-        "webm",
     ]),
 
     supportsAudioTrack(track: IAudioTrack) {

--- a/src/playback/player/chromecast.ts
+++ b/src/playback/player/chromecast.ts
@@ -58,6 +58,12 @@ const ultraCapabilities = {
         return this.audioCodecs.has(track.codec);
     },
 
+    supportsPixelFormat(format: string) {
+        // not documented, but discovered experimentally, with thanks
+        // for the hint to: https://github.com/petrkotek/chromecastize
+        return !format.includes("yuv444");
+    },
+
     supportsVideoTrack(track: IVideoTrack) {
         switch (track.codec) {
         case "vp8":

--- a/src/playback/serve.ts
+++ b/src/playback/serve.ts
@@ -7,6 +7,7 @@ import _debug from "debug";
 const debug = _debug("shougun:serve");
 
 import { Context } from "../context";
+import { analyzeFile } from "../media/analyze";
 import { extractDuration } from "../media/duration";
 import { BasePlayable } from "../media/playable-base";
 import { ILocalMedia, IMedia } from "../model";
@@ -253,6 +254,10 @@ export class ServedPlayable extends BasePlayable {
         public readonly durationSeconds: number,
     ) {
         super();
+    }
+
+    public async analyze() {
+        return analyzeFile(this.localPath);
     }
 
     public async getCoverUrl(context: Context) {

--- a/src/playback/serve.ts
+++ b/src/playback/serve.ts
@@ -9,12 +9,10 @@ const debug = _debug("shougun:serve");
 import { Context } from "../context";
 import { extractDuration } from "../media/duration";
 import { BasePlayable } from "../media/playable-base";
-import { isVideo } from "../media/util";
 import { ILocalMedia, IMedia } from "../model";
 import { withQuery } from "../util/url";
 import { IPlaybackOptions } from "./player";
-import { serveRanged } from "./serve/ranged";
-import { serveTranscoded } from "./serve/transcode";
+import { serveForPlayer } from "./serve/player-based";
 
 export interface IServer {
     /**
@@ -152,21 +150,12 @@ export class Server implements IServer {
 
         const { player } = context;
         const { contentType, localPath } = toPlay;
-        let stream: NodeJS.ReadableStream;
-        if (!isVideo(localPath) || player.getCapabilities().canPlayMime(contentType)) {
-            stream = await serveRanged(
-                req, reply, contentType, localPath,
-            );
-        } else if (player.getCapabilities().canPlayMime("video/mp4")) {
-            const startTime = req.query.startTime || 0;
-            debug(`serve transcoded from ${contentType} starting @`, startTime);
 
-            stream = await serveTranscoded(
-                req, reply, localPath, startTime,
-            );
-        } else {
-            throw new Error(`Player ${player} does not support ${contentType}`);
-        }
+        const stream = await serveForPlayer(
+            player,
+            req, reply,
+            contentType, localPath,
+        );
 
         debug("got stream");
         stream.once("close", onStreamEnded);

--- a/src/playback/serve/player-based.ts
+++ b/src/playback/serve/player-based.ts
@@ -5,7 +5,7 @@ import fastify from "fastify";
 
 import { analyzeFile } from "../../media/analyze";
 import { isVideo } from "../../media/util";
-import { IPlayer } from "../player";
+import { canPlayNatively, IPlayer } from "../player";
 
 import { serveRanged } from "./ranged";
 import { serveTranscodedForAnalysis } from "./transcode";
@@ -36,10 +36,7 @@ export async function serveForPlayer(
     ]);
 
     debug("analysis of", localPath, ":", analysis);
-    const videoSupported = capabilities.supportsVideoTrack(analysis.video);
-    const audioSupported = capabilities.supportsAudioTrack(analysis.audio);
-    const containerSupported = !!analysis.container.find(capabilities.supportsContainer.bind(capabilities));
-    const canStreamRanges = videoSupported && audioSupported && containerSupported;
+    const canStreamRanges = canPlayNatively(capabilities, analysis);
 
     if (!isVideo(localPath) || canStreamRanges) {
         debug(`serve ranges for ${localPath}`);

--- a/src/playback/serve/player-based.ts
+++ b/src/playback/serve/player-based.ts
@@ -39,8 +39,7 @@ export async function serveForPlayer(
     const videoSupported = capabilities.supportsVideoTrack(analysis.video);
     const audioSupported = capabilities.supportsAudioTrack(analysis.audio);
     const containerSupported = !!analysis.container.find(capabilities.supportsContainer.bind(capabilities));
-    const canStreamRanges = videoSupported && audioSupported && containerSupported
-        && analysis.video.codec === "h264";
+    const canStreamRanges = videoSupported && audioSupported && containerSupported;
 
     if (!isVideo(localPath) || canStreamRanges) {
         debug(`serve ranges for ${localPath}`);

--- a/src/playback/serve/player-based.ts
+++ b/src/playback/serve/player-based.ts
@@ -1,0 +1,64 @@
+import _debug from "debug";
+const debug = _debug("shougun:serve:player");
+
+import fastify from "fastify";
+
+import { analyzeFile } from "../../media/analyze";
+import { isVideo } from "../../media/util";
+import { IPlayer } from "../player";
+
+import { serveRanged } from "./ranged";
+import { serveTranscodedForAnalysis } from "./transcode";
+
+/**
+ * serveForPlayer analyzes the media and compares with the IPlayer's
+ * capabilities to determine the best way to serve the file, returning
+ * a NodeJS.ReadableStream
+ */
+export async function serveForPlayer(
+    player: IPlayer,
+    req: fastify.FastifyRequest<any>,
+    reply: fastify.FastifyReply<any>,
+    contentType: string,
+    localPath: string,
+): Promise<NodeJS.ReadableStream> {
+    if (!isVideo(localPath)) {
+        // quick shortcut for cover art, etc
+        debug(`serve ranges for non-video file: ${localPath}`);
+        return serveRanged(
+            req, reply, contentType, localPath,
+        );
+    }
+
+    const [ analysis, capabilities ] = await Promise.all([
+        analyzeFile(localPath),
+        player.getCapabilities(),
+    ]);
+
+    debug("analysis of", localPath, ":", analysis);
+    const videoSupported = capabilities.supportsVideoTrack(analysis.video);
+    const audioSupported = capabilities.supportsAudioTrack(analysis.audio);
+    const containerSupported = !!analysis.container.find(capabilities.supportsContainer.bind(capabilities));
+    const canStreamRanges = videoSupported && audioSupported && containerSupported
+        && analysis.video.codec === "h264";
+
+    if (!isVideo(localPath) || canStreamRanges) {
+        debug(`serve ranges for ${localPath}`);
+        return serveRanged(
+            req, reply, contentType, localPath,
+        );
+    }
+
+    if (!capabilities.canPlayMime("video/mp4")) {
+        // cannot transcode to mp4 either!
+        throw new Error(`Player ${player.constructor.name} does not support ${contentType}`);
+    }
+
+    const startTime = req.query.startTime || 0;
+    debug(`serve transcoded from ${contentType} starting @`, startTime);
+
+    return await serveTranscodedForAnalysis(
+        analysis, capabilities,
+        req, reply, localPath, startTime,
+    );
+}

--- a/src/playback/serve/player-based.ts
+++ b/src/playback/serve/player-based.ts
@@ -48,9 +48,18 @@ export async function serveForPlayer(
         );
     }
 
-    if (!capabilities.canPlayMime("video/mp4")) {
+    if (
+        !(
+            capabilities.supportsContainer("mp4")
+            && capabilities.supportsVideoTrack({
+                codec: "h264",
+                height: analysis.video.height,
+                width: analysis.video.width,
+            })
+        )
+    ) {
         // cannot transcode to mp4 either!
-        throw new Error(`Player ${player.constructor.name} does not support ${contentType}`);
+        throw new Error(`Player ${player.constructor.name} supports neither ${JSON.stringify(analysis)} nor media transcoded to mp4`);
     }
 
     const startTime = req.query.startTime || 0;

--- a/src/playback/serve/transcode.ts
+++ b/src/playback/serve/transcode.ts
@@ -80,6 +80,9 @@ export async function transcodeForAnalysis(
         config: command => {
             debug("configure transcoder with:", analysis);
 
+            // TODO: future work might downsample if the player doesn't
+            // support the given resolution
+
             if (capabilities.supportsVideoTrack(analysis.video)) {
                 debug("pass-through supported video track:", analysis.video);
                 command.videoCodec("copy");


### PR DESCRIPTION
Closes #13 

Per the commits:

> This makes our analysis and ffmpeg much more fine-grained, looking
at the actual codecs instead of just the file mime. This lets us
do pass-through muxing of supported tracks where possible, which
could significantly improve transcode performance and reduce potential
instances of buffering on particularly high-quality sources.