### PR TITLE
Support embedded text subtitles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,6 +1480,30 @@
         }
       }
     },
+    "fastify-cors": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-3.0.3.tgz",
+      "integrity": "sha512-SDMa+GtyTTAU7pWZwY4fukb/VwCZ4c30p0oEaE7/d/+VCvceB1+NzW2udp2dSZZfWR7J1kUookCpw2dLmtAsSw==",
+      "requires": {
+        "fastify-plugin": "^1.6.0",
+        "vary": "^1.1.2"
+      }
+    },
+    "fastify-plugin": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-1.6.1.tgz",
+      "integrity": "sha512-APBcb27s+MjaBIerFirYmBLatoPCgmHZM6XP0K+nDL9k0yX8NJPWDY1RAC3bh6z+AB5ULS2j31BUfLMT3uaZ4A==",
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "fastq": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
@@ -3786,6 +3810,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "crc": "^3.8.0",
     "debug": "^4.3.1",
     "fastify": "^2.15.3",
+    "fastify-cors": "^3.0.3",
     "fluent-ffmpeg": "^2.1.2",
     "fs-extra": "^9.1.0",
     "internal-ip": "^6.2.0",

--- a/src/media/analyze.ts
+++ b/src/media/analyze.ts
@@ -30,6 +30,7 @@ export interface ITextTrack {
     index: number;
     isDefault: boolean;
     isForced: boolean;
+    isHearingImpared: boolean;
     language?: string;
 }
 
@@ -184,5 +185,6 @@ function parseTextTrack(s: FfprobeStream): ITextTrack | undefined {
         codec: s.codec_name ?? '<unknown>',
         isDefault: !!s.disposition?.default,
         isForced: !!s.disposition?.forced,
+        isHearingImpared: !!s.disposition?.hearing_impaired,
     };
 }

--- a/src/media/analyze.ts
+++ b/src/media/analyze.ts
@@ -26,6 +26,7 @@ export interface IAudioTrack {
 }
 
 export interface ITextTrack {
+    codec: string;
     index: number;
     isDefault: boolean;
     isForced: boolean;
@@ -110,10 +111,6 @@ export async function analyzeFile(
                 subtitles.push(parsed);
             }
         }
-
-        // if (videoTrack && audioTrack) {
-        //     break;
-        // }
     }
 
     // couldn't find the requested track; fallback to the default
@@ -184,6 +181,7 @@ function parseTextTrack(s: FfprobeStream): ITextTrack | undefined {
     return {
         index: s.index,
         language,
+        codec: s.codec_name ?? '<unknown>',
         isDefault: !!s.disposition?.default,
         isForced: !!s.disposition?.forced,
     };

--- a/src/model.ts
+++ b/src/model.ts
@@ -81,6 +81,7 @@ export enum MediaType {
 
 export interface IMediaPrefs {
     preferredAudioLanguage?: string;
+    preferredSubtitleLanguage?: string;
 }
 
 export interface IMedia {

--- a/src/playback/player/apps/generic.ts
+++ b/src/playback/player/apps/generic.ts
@@ -162,6 +162,7 @@ function formatLoadRequest(
 ) {
     const media = formatCastInfo(params.media);
     const activeTrackIds = pickDefaultTrackIds(params);
+    debug("Picked active tracks:", activeTrackIds);
 
     const request = {
         activeTrackIds,

--- a/src/playback/player/apps/generic.ts
+++ b/src/playback/player/apps/generic.ts
@@ -14,6 +14,18 @@ export interface ICustomCastData {
     startTimeAbsolute?: number;
 }
 
+export interface ICastTrack {
+    /** RFC 5646; mandatory for SUBTITLES */
+    language?: string;
+    name?: string;
+    /** The URL */
+    trackContentId: string;
+    trackContentType?: "text/webvtt" | "text/vtt" | string; // shrug?
+    trackId: number;
+    type: "AUDIO" | "TEXT" | "VIDEO";
+    subtype?: "SUBTITLES" | "CAPTIONS";
+}
+
 export interface ICastInfo {
     contentType: any;
     currentTime?: number;
@@ -28,6 +40,7 @@ export interface ICastInfo {
     id: string;
     url: string;
     metadata?: IMediaMetadata;
+    tracks?: ICastTrack[];
 
     source: IMedia;
 }
@@ -108,12 +121,21 @@ function formatMetadata(
 }
 
 function formatCastInfo(info: ICastInfo) {
+    // TODO preferred track preference?
+    let activeTrackIds: number[] | undefined;
+    if (info.tracks && info.tracks.length) {
+        activeTrackIds = [info.tracks[0].trackId];
+    }
+
     return {
+        activeTrackIds,
         contentId: info.id,
         contentType: info.contentType,
         contentUrl: info.url,
         duration: info.duration,
         metadata: formatMetadata(info.metadata),
+        textTrackStyle: {},
+        tracks: info.tracks,
     };
 }
 

--- a/src/playback/player/chromecast.ts
+++ b/src/playback/player/chromecast.ts
@@ -434,7 +434,7 @@ function tracksFrom(
             trackContentId: makeSubtitleUrl(mediaUrl, track),
             trackContentType: "text/vtt",
             trackId: track.index,
-            subtype: "SUBTITLES", // TODO: we may be able to use "captions" for some
+            subtype: "SUBTITLES", // TODO: we may be able to use "captions" for some dispositions
             type: "TEXT",
         });
     }

--- a/src/playback/player/chromecast.ts
+++ b/src/playback/player/chromecast.ts
@@ -403,14 +403,6 @@ function pickAppTypeFor(
     return DefaultMediaReceiverApp;
 }
 
-function formatLanguage(rawLanguage: string) {
-    if (rawLanguage.length > 2) {
-        return rawLanguage.substring(0, 2);
-    }
-
-    return rawLanguage;
-}
-
 function makeSubtitleUrl(mediaUrl: string, track: ITextTrack) {
     // FIXME: This should probably be provided by the Playable
     return `${mediaUrl}/subtitles/${track.index}`;
@@ -428,7 +420,7 @@ function tracksFrom(
 
     tracks.push({
         customData: analysis.audio,
-        language: formatLanguage(analysis.audio.language ?? "en"),
+        language: analysis.audio.language,
         name: "Audio Track",
         trackContentId: "trk0001",
         trackContentType: "audio/" + analysis.audio.codec,
@@ -448,7 +440,7 @@ function tracksFrom(
 
         tracks.push({
             customData: track,
-            language: formatLanguage(track.language),
+            language: track.language,
             name: track.language,
             trackContentId: makeSubtitleUrl(mediaUrl, track),
             trackContentType: "text/vtt",

--- a/src/playback/player/chromecast.ts
+++ b/src/playback/player/chromecast.ts
@@ -331,6 +331,7 @@ export class ChromecastPlayer implements IPlayer {
             media,
             queueAround,
             preferredAudioLanguage: playable.media.prefs?.preferredAudioLanguage,
+            preferredSubtitleLanguage: playable.media.prefs?.preferredSubtitleLanguage,
 
             onPlayerPaused: opts.onPlayerPaused,
             onPlayerStop() {

--- a/src/playback/player/chromecast.ts
+++ b/src/playback/player/chromecast.ts
@@ -426,6 +426,16 @@ function tracksFrom(
 ): ICastTrack[] | undefined {
     const tracks: ICastTrack[] = [];
 
+    tracks.push({
+        customData: analysis.audio,
+        language: formatLanguage(analysis.audio.language ?? "en"),
+        name: "Audio Track",
+        trackContentId: "trk0001",
+        trackContentType: "audio/" + analysis.audio.codec,
+        trackId: analysis.audio.index,
+        type: "AUDIO",
+    });
+
     for (const track of analysis.subtitles) {
         if (!track.language) continue;
 
@@ -437,6 +447,7 @@ function tracksFrom(
         }
 
         tracks.push({
+            customData: track,
             language: formatLanguage(track.language),
             name: track.language,
             trackContentId: makeSubtitleUrl(mediaUrl, track),

--- a/src/playback/player/track-selection.ts
+++ b/src/playback/player/track-selection.ts
@@ -1,0 +1,47 @@
+import { languageCodeMatches } from "../../util/language";
+import { ICastTrack, ILoadParams } from "./apps/generic";
+
+export function findDefaultAudio(tracks: ICastTrack[]) {
+    for (const track of tracks) {
+        if (track.type === "AUDIO") {
+            return track.customData;
+        }
+    }
+}
+
+export function pickDefaultTrackIds(
+    params: ILoadParams,
+) {
+    if (!params.media.tracks || !params.media.tracks.length) {
+        // No tracks; don't bother
+        return;
+    }
+
+    if (params.preferredSubtitleLanguage != null) {
+        // If we have a preferred subtitle language, try to honor it
+        const preferred = params.media.tracks.find(track =>
+            track.language
+            && languageCodeMatches(track.language, params.preferredSubtitleLanguage!)
+        );
+        if (preferred) {
+            return [preferred.trackId];
+        }
+    }
+
+    // Try to honor a "forced" subtitle track. These should be enabled by
+    // default if the subtitle language matches the selected audio language
+    // *and* the subtitle has the "isForced" flag.
+    const audio = findDefaultAudio(params.media.tracks);
+    if (!audio) {
+        // Unlikely, but...
+        return;
+    }
+
+    for (const track of params.media.tracks) {
+        if (track.type !== "TEXT") continue;
+
+        if (track.customData.isForced && track.language === audio.language) {
+            return [track.trackId];
+        }
+    }
+}

--- a/src/playback/serve.ts
+++ b/src/playback/serve.ts
@@ -1,4 +1,5 @@
 import fastify from "fastify";
+import cors from "fastify-cors";
 import internalIp = require("internal-ip");
 import mime from "mime";
 import url from "url";
@@ -95,6 +96,10 @@ export class Server implements IServer {
             // NOTE: some IDs may be arbitrarily long file paths;
             // let's support that
             maxParamLength: 512,
+        });
+
+        server.register(cors as any, {
+            origin: true,
         });
 
         server.get("/playable/id/:id/subtitles/:track", async (req, reply) => {
@@ -231,6 +236,10 @@ export class Server implements IServer {
         const stream = await extractSubtitlesTrack(localPath, track);
 
         debug("got stream @", req.headers.range);
+        reply.headers({
+            "Content-Type": "text/vtt",
+            "Accept-Encoding": "*",
+        });
         reply.status(200);
 
         stream.once("close", () => {

--- a/src/playback/serve/ffmpeg.ts
+++ b/src/playback/serve/ffmpeg.ts
@@ -1,0 +1,58 @@
+import _debug from "debug";
+const debug = _debug("shougun:serve:ffmpeg");
+
+import ffmpeg from "fluent-ffmpeg";
+import stream from "stream";
+
+export interface IFfmpegOpts {
+    autoEnd?: boolean;
+    config?: (cmd: ffmpeg.FfmpegCommand) => void,
+}
+
+export const ffmpegAsPromise = (
+    logContext: string,
+    command: ffmpeg.FfmpegCommand,
+    opts: IFfmpegOpts = {},
+    pipe: stream.PassThrough = new stream.PassThrough(),
+) => new Promise<stream.PassThrough>((resolve, reject) => {
+    command
+        .on("start", cmd => {
+            debug("start", logContext, ":", cmd);
+        })
+        .once("progress", data => {
+            debug("progress @", logContext);
+            resolve(pipe);
+        })
+        .on("error", e => {
+            debug("error", logContext, e);
+            reject(e);
+        })
+        .on("end", () => {
+            debug("done", logContext);
+            pipe.end();
+        });
+
+    if (opts.config) {
+        opts.config(command);
+    }
+
+    pipe.once("close", () => {
+        // the user stopped viewing the stream; stop transcoding
+        debug("pipe closed; shut down:", logContext);
+        command.kill("SIGKILL");
+    });
+
+    // don't end it automatically (IE on error); we'll do it
+    // ourselves (see above)
+    const end = opts.autoEnd === true;
+    command.output(pipe, { end }).run();
+
+    // HACKS: if we don't get an error *or* otherwise resolve in 1s,
+    // just resolve so we can *try* to read from the pipe.
+    // TODO: Perhaps if `pipe` read from the command output but stored
+    // it in a buffer until downstream was ready to consume, it'd work
+    // without this hack?
+    setTimeout(() => {
+        resolve(pipe);
+    }, 1000);
+});

--- a/src/playback/serve/subtitle.ts
+++ b/src/playback/serve/subtitle.ts
@@ -1,48 +1,21 @@
 import _debug from "debug";
-const debug = _debug("shougun:subtitle");
 
 import ffmpeg from "fluent-ffmpeg";
-import stream = require("stream");
 
 import { ITextTrack } from "../../media/analyze";
+import { ffmpegAsPromise, IFfmpegOpts } from "./ffmpeg";
 
-export const extractSubtitlesTrack = (
+export function extractSubtitlesTrack(
     localPath: string,
     track: ITextTrack,
-    opts: { autoEnd?: boolean } = {},
-) => new Promise<stream.PassThrough>((resolve, reject) => {
-    const pipe = new stream.PassThrough();
-
+    opts: IFfmpegOpts = {},
+) {
     // NOTE: Using the .map() method causes the library to wrap our stream
     // selection in [brackets] which apparently breaks it? Not sure what's
     // the deal there....
     const command = ffmpeg(localPath)
         .outputOption("-map", `0:${track.index}`)
-        .outputFormat("webvtt")
-        .on("error", e => {
-            debug("error extracting subtitles", localPath, e);
-            reject(e);
-        })
-        .on("end", () => {
-            debug("done extracting subtitles @", localPath);
-            pipe.end();
-        });
+        .outputFormat("webvtt");
 
-    pipe.once("close", () => {
-        // the user stopped viewing the stream; stop transcoding
-        debug("pipe closed; shut down transcode");
-        command.kill("SIGKILL");
-    });
-
-    // don't end it automatically (IE on error); we'll do it
-    // ourselves (see above)
-    const end = opts.autoEnd === true;
-    command.output(pipe, { end }).run();
-
-    debug("end=", end);
-
-    // See HACKS in transcode.ts
-    setTimeout(() => {
-        resolve(pipe);
-    }, 1000);
-});
+    return ffmpegAsPromise(`extract subtitles from ${localPath}`, command, opts);
+}

--- a/src/playback/serve/subtitle.ts
+++ b/src/playback/serve/subtitle.ts
@@ -1,0 +1,29 @@
+import _debug from "debug";
+const debug = _debug("shougun:subtitle");
+
+import ffmpeg from "fluent-ffmpeg";
+import stream = require("stream");
+
+import { ITextTrack } from "../../media/analyze";
+
+export async function extractSubtitlesTrack(
+    localPath: string,
+    track: ITextTrack,
+) {
+    const pipe = new stream.PassThrough();
+
+    const command = ffmpeg(localPath)
+        .map("0:s:0")
+        .outputFormat("webvtt");
+        // .map(`0:${track.index}`);
+
+    pipe.once("close", () => {
+        // the user stopped viewing the stream; stop transcoding
+        debug("pipe closed; shut down transcode");
+        command.kill("SIGKILL");
+    });
+
+    command.output(pipe).run();
+
+    return pipe;
+}

--- a/src/playback/serve/subtitle.ts
+++ b/src/playback/serve/subtitle.ts
@@ -12,10 +12,12 @@ export async function extractSubtitlesTrack(
 ) {
     const pipe = new stream.PassThrough();
 
+    // NOTE: Using the .map() method causes the library to wrap our stream
+    // selection in [brackets] which apparently breaks it? Not sure what's
+    // the deal there....
     const command = ffmpeg(localPath)
-        .map("0:s:0")
+        .outputOption("-map", `0:${track.index}`)
         .outputFormat("webvtt");
-        // .map(`0:${track.index}`);
 
     pipe.once("close", () => {
         // the user stopped viewing the stream; stop transcoding


### PR DESCRIPTION
In addition to sending the tracks along to the Chromecast and serving them via HTTP, this PR will also attempt to respect the "forced" flag on a subtitle track, selecting it by default IFF the language of the "forced" track matches the language of the selected audio track.

- Experiment with extracting embedded subtitles
- Fix subtitle extraction + extract subtitle codec
- Send subtitle track information to chromecast
- Improve subtitle stream error capture
- Enable CORS to fix subtitle streaming
- Respect "preferred subtitle language" for selecting default subtitles
- Label text tracks as CAPTIONS if appropriate
- Refactor to share ffmpeg stream init logic
- Forward preferredSubtitleLanguage from IMediaPrefs
- Attempt to respect "forced" subtitle tracks
