### PR TITLE
Add support for RPC-powered babbling auth updates

### DIFF
--- a/src/queryables/babbling.ts
+++ b/src/queryables/babbling.ts
@@ -57,7 +57,7 @@ async function* transformQueryResultsToPlayableMedia(
 
 export class BabblingQueryable implements IQueryable {
     constructor(
-        private readonly configPath?: string,
+        public readonly configPath?: string,
         private readonly chromecastDeviceName?: string,
     ) {}
 

--- a/src/rpc/msgpack.ts
+++ b/src/rpc/msgpack.ts
@@ -147,7 +147,7 @@ export function createPublishedMethodsHandler(
                 if (method.startsWith("_")) {
                     throw new Error(`Invalid method name: ${method}`);
                 }
-                debug("invoke", method, params);
+                debug("invoke", method);
                 return (receiver as any)[method](...params);
             })();
 


### PR DESCRIPTION
This will enable us to perform provider auth via a remote client. Much
more convenient for providers that require re-auth quite frequently.

This *should* only be done over a secure LAN so this *should* be fine...
but it may still behoove us to encrypt this data transfer at some point....
