### PR TITLE
Attempt to improve support for fast-forwarding in queued media

### DIFF
--- a/src/playback/serve/player-based.ts
+++ b/src/playback/serve/player-based.ts
@@ -58,12 +58,9 @@ export async function serveForPlayer(
         )
     ) {
         // cannot transcode to mp4 either!
+        const analysisJson = JSON.stringify(analysis);
         throw new Error(
-            `Player ${
-                player.constructor.name
-            } supports neither ${JSON.stringify(
-                analysis,
-            )} nor media transcoded to mp4`,
+            `Player ${player.constructor.name} supports neither ${analysisJson} nor media transcoded to mp4`,
         );
     }
 

--- a/src/playback/serve/player-based.ts
+++ b/src/playback/serve/player-based.ts
@@ -41,7 +41,7 @@ export async function serveForPlayer(
     debug("analysis of", localPath, ":", analysis);
     const canStreamRanges = canPlayNatively(capabilities, analysis);
 
-    if (!isVideo(localPath) || canStreamRanges) {
+    if (canStreamRanges) {
         debug(`serve ranges for ${contentType}: ${localPath}`);
         return serveRanged(req, reply, contentType, localPath);
     }


### PR DESCRIPTION
From the commit:

>    I think this will help with skipping in non-natively-playable media
>    types. It seems like I'm mostly encountering the issue with being unable
>    to skip properly after going to the "next" episode; currently, only the
>    explicitly requested media has the duration, so *perhaps* the Chromecast
>    isn't passing the proper timestamp if it's past whatever it believes is
>    the duration of the video (which is basically however long it's played).

