### PR TITLE
Attempt to "inflate" media directly for RPC playback

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -135,6 +135,8 @@ export type ProviderErrorHandler = (provider: string, error: Error) => void;
  * Queryable abstraction
  */
 export interface IQueryable {
+    inflateQueriedMedia?(media: IMedia): Promise<IMedia>;
+    isProviderFor(media: IMedia): boolean;
     queryRecent(
         context: Context,
         onError?: ProviderErrorHandler,

--- a/src/queryables/context.ts
+++ b/src/queryables/context.ts
@@ -1,5 +1,5 @@
 import { Context } from "../context";
-import { IMedia, IQueryable } from "../model";
+import { IMedia, IQueryable, MediaType } from "../model";
 
 /**
  * The ContextQueryable is a core component that provides query results from
@@ -7,6 +7,10 @@ import { IMedia, IQueryable } from "../model";
  * will not get any results from local Discovery.
  */
 export class ContextQueryable implements IQueryable {
+    public isProviderFor(media: IMedia): boolean {
+        return media.type !== MediaType.ExternalPlayable;
+    }
+
     public async *findMedia(
         context: Context,
         query: string,

--- a/src/rpc/methods/v1.ts
+++ b/src/rpc/methods/v1.ts
@@ -177,8 +177,10 @@ export default class RpcMethodsV1 {
     }
 
     public async start(media: IMedia) {
+        debug("inflating...", media.id);
         const inflated = await this.shougun.inflateQueriedMedia(media);
         try {
+            debug("inflated:", inflated);
             await this.shougun.play(inflated);
         } catch (e) {
             debug(
@@ -198,11 +200,11 @@ export default class RpcMethodsV1 {
                     return this.shougun.play(c);
                 }
             }
-        }
 
-        throw new Error(
-            `No media with title ${media.title} and ID ${media.id}`,
-        );
+            throw new Error(
+                `No media with title ${media.title} and ID ${media.id}`,
+            );
+        }
     }
 
     public async startByPath(path: string, options: IPlaybackOptions = {}) {

--- a/src/rpc/methods/v1.ts
+++ b/src/rpc/methods/v1.ts
@@ -177,12 +177,26 @@ export default class RpcMethodsV1 {
     }
 
     public async start(media: IMedia) {
-        const candidates = await this.shougun.search(media.title);
-        if (!candidates) throw new Error(`No results for ${media.title}`);
+        const inflated = await this.shougun.inflateQueriedMedia(media);
+        try {
+            await this.shougun.play(inflated);
+        } catch (e) {
+            debug(
+                "Failed to play inflated media:",
+                inflated,
+                "; original=",
+                media,
+                ";\nCause:",
+                e,
+            );
 
-        for (const c of candidates) {
-            if (c.discovery === media.discovery && c.id === media.id) {
-                return this.shougun.play(c);
+            const candidates = await this.shougun.search(media.title);
+            if (!candidates) throw new Error(`No results for ${media.title}`);
+
+            for (const c of candidates) {
+                if (c.discovery === media.discovery && c.id === media.id) {
+                    return this.shougun.play(c);
+                }
             }
         }
 

--- a/src/shougun.ts
+++ b/src/shougun.ts
@@ -105,6 +105,14 @@ export class Shougun {
     }
 
     /**
+     *
+     */
+    public async inflateQueriedMedia(media: IMedia) {
+        const source = this.queryableFor(media);
+        return source.inflateQueriedMedia?.(media) ?? media;
+    }
+
+    /**
      * Get a map whose keys are a discovery type and whose values
      * are AsyncIterables of recently watched media
      */
@@ -331,6 +339,19 @@ export class Shougun {
         }
 
         return resultsBySource;
+    }
+
+    private queryableFor(media: IMedia) {
+        for (const queryable of this.context.queryables) {
+            if (queryable.isProviderFor(media)) {
+                return queryable;
+            }
+        }
+        throw new Error(
+            `No registered Queryable claimed ownership of ${JSON.stringify(
+                media,
+            )}`,
+        );
     }
 
     private async *queryFromMap(


### PR DESCRIPTION
Our previous attempt repeated the search locally with the given title to
get the search result object, since that object is how we interop with external
playables. However, there's non-trivial latency involved in performing this search—usually about a second, but potentially longer since we're querying all connected services. Of course, the latency involved in starting the Chromecast app and starting playback completely dwarfs that (about 20s for HBO, for example) but a win's a win.

This approach leans on babbling's `playUrl` functionality, which we have
in the media's ID, to attempt to play the requested media directly and
skip the search step. In theory this should always work, but we still
fallback to the search-based approach *just in case*.

At some point we should consider separating the `IMedia` interface to
more clearly describe when it's a serialized media object from eg RPC vs
an *actual* object returned by a Queryable that can be safely played
directly....
