### PR TITLE
Return distinct results for recent vs recommended

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@types/msgpack-lite": "^0.1.8",
-                "babbling": "^3.5.1",
+                "babbling": "^3.6.1",
                 "better-sqlite3": "^8.0.1",
                 "chai-as-promised": "^7.1.1",
                 "chokidar": "^3.5.3",
@@ -1243,9 +1243,9 @@
             "peer": true
         },
         "node_modules/babbling": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/babbling/-/babbling-3.5.1.tgz",
-            "integrity": "sha512-J/yiye8E+4XOpvB8muHco4hoGvNamU58BQCLAK6pMFKgCxFQJYpRB/Bkh+9QDJDi6qZKppotfBlrnvAuEEdxtA==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/babbling/-/babbling-3.6.1.tgz",
+            "integrity": "sha512-S4mRgqp/TSMXVZiNXEQF4hVkx4uODmVxNSzkgoSzH0AwsV/jJn/AM7FKgCFtZ3wSYgZjhYXq+MY/zyadE+G5YA==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "chakram-ts": "^1.0.0",
@@ -8864,9 +8864,9 @@
             "peer": true
         },
         "babbling": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/babbling/-/babbling-3.5.1.tgz",
-            "integrity": "sha512-J/yiye8E+4XOpvB8muHco4hoGvNamU58BQCLAK6pMFKgCxFQJYpRB/Bkh+9QDJDi6qZKppotfBlrnvAuEEdxtA==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/babbling/-/babbling-3.6.1.tgz",
+            "integrity": "sha512-S4mRgqp/TSMXVZiNXEQF4hVkx4uODmVxNSzkgoSzH0AwsV/jJn/AM7FKgCFtZ3wSYgZjhYXq+MY/zyadE+G5YA==",
             "requires": {
                 "abort-controller": "^3.0.0",
                 "chakram-ts": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "homepage": "https://github.com/dhleong/shougun#readme",
     "dependencies": {
         "@types/msgpack-lite": "^0.1.8",
-        "babbling": "^3.5.1",
+        "babbling": "^3.6.1",
         "better-sqlite3": "^8.0.1",
         "chai-as-promised": "^7.1.1",
         "chokidar": "^3.5.3",

--- a/src/queryables/babbling.ts
+++ b/src/queryables/babbling.ts
@@ -1,7 +1,11 @@
 import _debug from "debug";
 
 import { ChromecastDevice, PlayerBuilder } from "babbling";
-import { IPlayableOptions, IQueryResult } from "babbling/dist/app";
+import {
+    IPlayableOptions,
+    IQueryResult,
+    RecommendationType,
+} from "babbling/dist/app";
 
 import { Context } from "../context";
 import {
@@ -22,6 +26,10 @@ type Player = PromiseType<ReturnType<BabblingQueryable["getPlayer"]>>;
 
 function queryErrorHandler(app: string, error: unknown) {
     debug("error querying", app, error);
+}
+
+function packQueryOpts(onError?: (app: string, error: Error) => void) {
+    return { onError: onError ?? queryErrorHandler };
 }
 
 function shougunOptsToBabblingOpts(
@@ -125,9 +133,8 @@ export class BabblingQueryable implements IQueryable {
     ): Promise<IMediaResultsMap> {
         // NOTE: babbling doesn't technically support recents yet, but actually
         // all the implementations return that, so just do it for now
-        // TODO: whenever babbling adds getRecentsMap, use that
         return this.getMediaMapBy((p) =>
-            p.getRecommendationsMap(onError ?? queryErrorHandler),
+            p.getRecentsMap(packQueryOpts(onError)),
         );
     }
 
@@ -136,7 +143,12 @@ export class BabblingQueryable implements IQueryable {
         onError?: (app: string, error: Error) => void,
     ): Promise<IMediaResultsMap> {
         return this.getMediaMapBy((p) =>
-            p.getRecommendationsMap(onError ?? queryErrorHandler),
+            p.getQueryRecommendationsMap(
+                {
+                    excludeTypes: [RecommendationType.Recent],
+                },
+                packQueryOpts(onError),
+            ),
         );
     }
 


### PR DESCRIPTION
Mostly just leaning on the work in Babbling, but we also try to "recommend" un(recently)watched media from the local provider, as well.

- Update babbling and use its new queryRecent/queryRecommendations map
- Add a rough mechanism to "recommend" unwatched local media
